### PR TITLE
Fix DocumentState list field defaults

### DIFF
--- a/src/mind_sonic/models.py
+++ b/src/mind_sonic/models.py
@@ -5,7 +5,7 @@ MindSonic Data Models
 This module contains the data models used throughout the MindSonic application.
 """
 from typing import List
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class DocumentState(BaseModel):
@@ -13,13 +13,13 @@ class DocumentState(BaseModel):
     
     Each attribute represents a collection of files of a specific type.
     """
-    list_txt: List[str] = []
-    list_csv: List[str] = []
-    list_docx: List[str] = []
-    list_html: List[str] = []
-    list_md: List[str] = []
-    list_pdf: List[str] = []
-    list_xlsx: List[str] = []
+    list_txt: List[str] = Field(default_factory=list)
+    list_csv: List[str] = Field(default_factory=list)
+    list_docx: List[str] = Field(default_factory=list)
+    list_html: List[str] = Field(default_factory=list)
+    list_md: List[str] = Field(default_factory=list)
+    list_pdf: List[str] = Field(default_factory=list)
+    list_xlsx: List[str] = Field(default_factory=list)
 
 
 class SonicState(BaseModel):


### PR DESCRIPTION
## Summary
- use `Field(default_factory=list)` for all lists in `DocumentState`
- import `Field` from pydantic
- run `py_compile` to ensure syntax is valid

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846bddf04708325a8d475d2bbbe2f08