### PR TITLE
Add CLI query option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ To kickstart your flow and begin execution, run this from the root folder of you
 crewai run
 ```
 
+You can also provide a custom query directly:
+
+```bash
+python -m mind_sonic.main --query "Tell me about AI"
+```
+
+If no query is supplied, MindSonic will look for `request.txt` in the
+`src/mind_sonic` directory and use its contents.
+
 To visualize the flow structure:
 
 ```bash


### PR DESCRIPTION
## Summary
- add argparse handler for `--query`
- fallback to request.txt when query is not specified
- document new CLI flag in README

## Testing
- `pytest -q` *(fails: pyenv missing python and pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6846be0271a883259be63b97e019a830