### PR TITLE
Add file-based logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ lib/
 *.html
 *.pdf
 *.xlsx
-storage/chroma
+storage/chroma/
+logs/*
+!logs/.gitkeep

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ The MindSonic flow follows a simple pattern:
 
 The flow is visualized in `crewai_flow.html` which you can view in any browser.
 
+## Logging
+
+During execution, MindSonic writes two log files to the `logs` folder:
+
+- `trace.log` records all log messages for later inspection
+- `errors.log` captures only error messages for quick troubleshooting
+
+Both files are created automatically when you run the flow.
+
 ## Documentation
 
 Additional documentation can be found in the `documentation` folder:

--- a/src/mind_sonic/main.py
+++ b/src/mind_sonic/main.py
@@ -7,6 +7,28 @@ and generating a poem using CrewAI. The design follows KISS, YAGNI, and DRY prin
 """
 from typing import List
 from pathlib import Path
+import logging
+
+# Create logs directory
+LOG_DIR = Path(__file__).resolve().parents[2] / "logs"
+LOG_DIR.mkdir(exist_ok=True)
+
+_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+trace_handler = logging.FileHandler(LOG_DIR / "trace.log")
+trace_handler.setLevel(logging.INFO)
+
+error_handler = logging.FileHandler(LOG_DIR / "errors.log")
+error_handler.setLevel(logging.ERROR)
+
+stream_handler = logging.StreamHandler()
+stream_handler.setLevel(logging.INFO)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format=_LOG_FORMAT,
+    handlers=[trace_handler, error_handler, stream_handler],
+)
 
 from crewai.flow import Flow, listen, start, router, and_
 from mind_sonic.crews.poem_crew.poem_crew import PoemCrew
@@ -16,6 +38,8 @@ from mind_sonic.models import DocumentState, SonicState
 from mind_sonic.utils.file_finder import find_files
 from mind_sonic.utils.file_processor import process_files
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 
 def read_file(file_path: str) -> str:
@@ -35,14 +59,14 @@ class SonicFlow(Flow[SonicState]):
     @start()
     def list_files(self):
         """Entry point: find all files to process."""
-        print("Listing files")
+        logger.info("Listing files")
         document_state = DocumentState()
         self.state.document_state = find_files("knowledge", document_state)
 
     @router(list_files)
     def start_indexing(self):
         """Route to parallel indexing processes."""
-        print("Starting indexing")
+        logger.info("Starting indexing")
 
 
 
@@ -95,13 +119,13 @@ class SonicFlow(Flow[SonicState]):
     )
     def end_indexing(self):
         """Meeting point after all files are processed."""
-        print("Indexing done")
+        logger.info("Indexing done")
 
 
     @listen(end_indexing)
     def start_research(self):
         """Start research after indexing."""
-        print("Starting research")
+        logger.info("Starting research")
         
         request = read_file("src/mind_sonic/request.txt")
         inputs={
@@ -114,10 +138,10 @@ class SonicFlow(Flow[SonicState]):
     @listen(start_research)
     def end_research(self):
         """Generate a poem after research."""
-        print("Research done, let's finish with a poem")
+        logger.info("Research done, let's finish with a poem")
         poem = PoemCrew().crew().kickoff()
         self.state.poem = poem
-        print(poem)
+        logger.info(poem)
 
 def kickoff() -> None:
     """Start the SonicFlow execution."""

--- a/src/mind_sonic/utils/file_processor.py
+++ b/src/mind_sonic/utils/file_processor.py
@@ -6,9 +6,12 @@ This module contains utilities for processing files of various types.
 """
 from pathlib import Path
 from typing import List
+import logging
 
 from mind_sonic.crews.indexer_crew.indexer_crew import IndexerCrew
 from mind_sonic.utils.file_archiver import archive_files
+
+logger = logging.getLogger(__name__)
 
 
 def process_files(file_list: List[str], file_type: str) -> None:
@@ -18,13 +21,13 @@ def process_files(file_list: List[str], file_type: str) -> None:
         file_list: List of files to process
         file_type: Type of files being processed
     """
-    print(f"Indexing {file_type}")
+    logger.info("Indexing %s", file_type)
     for file in file_list:
-        print(Path(file).name)
+        logger.info(Path(file).name)
         try:
             indexer = IndexerCrew()
             result = indexer.process_file({"file": file, "suffix": file_type})
-            print(result)
+            logger.info(result)
             archive_files(file)
         except Exception as e:
-            print(f"Error indexing {file}: {e}")
+            logger.error("Error indexing %s: %s", file, e)


### PR DESCRIPTION
## Summary
- configure logging handlers to create trace and error logs
- document log files location
- ignore log files and keep folder via `.gitkeep`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6846be1922848325b279dd1c66134f92